### PR TITLE
Fix wget regex

### DIFF
--- a/measurement/plugins/download_speed/measurements.py
+++ b/measurement/plugins/download_speed/measurements.py
@@ -14,7 +14,7 @@ from measurement.results import Error
 from measurement.units import NetworkUnit, StorageUnit
 
 WGET_OUTPUT_REGEX = re.compile(
-    r"\((?P<download_rate>[\d.]*)\s(?P<download_unit>.*)\).*\[(?P<download_size>\d*)\]"
+    r"\((?P<download_rate>[\d.]*)\s(?P<download_unit>.*)\).*\[(?P<download_size>\d*)[\]/]"
 )
 LATENCY_OUTPUT_REGEX = re.compile(
     r"= (?P<minimum_latency>[\d.].*)/(?P<average_latency>[\d.].*)/(?P<maximum_latency>[\d.].*)/(?P<median_deviation>[\d.].*) "


### PR DESCRIPTION
Sometimes wget outputs the download size just as the total number other
times it does a downloaded out of download size. We use what it actually
downloaded.