### PR TITLE
Fix download test units

### DIFF
--- a/measurement/plugins/download_speed/measurements.py
+++ b/measurement/plugins/download_speed/measurements.py
@@ -224,7 +224,7 @@ class DownloadSpeedMeasurement(BaseMeasurement):
             )
         except ValueError:
             return self._get_wget_error(
-                "wget-storage-unit", url, traceback=wget_out.stderr
+                "wget-download-unit", url, traceback=wget_out.stderr
             )
 
         try:
@@ -247,7 +247,7 @@ class DownloadSpeedMeasurement(BaseMeasurement):
             download_rate_unit=download_rate_unit,
             download_rate=download_rate,
             download_size=download_size,
-            download_size_unit=StorageUnit.megabit,
+            download_size_unit=StorageUnit.bit,
             errors=[],
         )
 

--- a/measurement/plugins/download_speed/measurements.py
+++ b/measurement/plugins/download_speed/measurements.py
@@ -43,6 +43,10 @@ LATENCY_ERRORS = {
     "ping-timeout": "Measurement request timed out.",
 }
 
+WGET_DOWNLOAD_RATE_UNIT_MAP = {
+    "KB/s": NetworkUnit("Kibit/s"),
+    "MB/s": NetworkUnit("Mibit/s"),
+}
 
 class DownloadSpeedMeasurement(BaseMeasurement):
     """A measurement designed to test download speed."""
@@ -219,16 +223,14 @@ class DownloadSpeedMeasurement(BaseMeasurement):
             return self._get_wget_error("wget-regex", url, traceback=wget_out.stderr)
 
         try:
-            download_rate_unit = NetworkUnit(
-                match_data.get("download_unit").replace("MB/s", "Mibit/s")
-            )
-        except ValueError:
+            download_rate_unit = WGET_DOWNLOAD_RATE_UNIT_MAP[match_data.get("download_unit")]
+        except KeyError:
             return self._get_wget_error(
                 "wget-download-unit", url, traceback=wget_out.stderr
             )
 
         try:
-            # NOTE: wget returns download rate in MiB/s. Convert to Mibit/s.
+            # NOTE: wget returns download rate in [K|M]B/s. Convert to [K|M]ibit/s.
             download_rate = float(match_data.get("download_rate")) * 8
         except (TypeError, ValueError):
             return self._get_wget_error(

--- a/measurement/plugins/download_speed/measurements.py
+++ b/measurement/plugins/download_speed/measurements.py
@@ -25,7 +25,7 @@ WGET_ERRORS = {
     "wget-err": "wget had an unknown error.",
     "wget-split": "wget attempted to split the result but it was in an unanticipated format.",
     "wget-regex": "wget attempted get the known regex format and failed.",
-    "wget-storage-unit": "wget could not process the storage unit.",
+    "wget-download-unit": "wget could not process the download unit.",
     "wget-download-rate": "wget could not process the download rate.",
     "wget-download-size": "wget could not process the download size.",
     "wget-no-server": "No closest server could be resolved.",
@@ -219,8 +219,8 @@ class DownloadSpeedMeasurement(BaseMeasurement):
             return self._get_wget_error("wget-regex", url, traceback=wget_out.stderr)
 
         try:
-            storage_unit = NetworkUnit(
-                match_data.get("download_unit").replace("MB/s", "Mbit/s")
+            download_rate_unit = NetworkUnit(
+                match_data.get("download_unit").replace("MB/s", "Mibit/s")
             )
         except ValueError:
             return self._get_wget_error(
@@ -228,7 +228,8 @@ class DownloadSpeedMeasurement(BaseMeasurement):
             )
 
         try:
-            download_rate = float(match_data.get("download_rate"))
+            # NOTE: wget returns download rate in MiB/s. Convert to Mibit/s.
+            download_rate = float(match_data.get("download_rate")) * 8
         except (TypeError, ValueError):
             return self._get_wget_error(
                 "wget-download-rate", url, traceback=wget_out.stderr
@@ -243,7 +244,7 @@ class DownloadSpeedMeasurement(BaseMeasurement):
         return DownloadSpeedMeasurementResult(
             id=self.id,
             url=url,
-            download_rate_unit=storage_unit,
+            download_rate_unit=download_rate_unit,
             download_rate=download_rate,
             download_size=download_size,
             download_size_unit=StorageUnit.megabit,

--- a/measurement/plugins/download_speed/tests/test_measurements.py
+++ b/measurement/plugins/download_speed/tests/test_measurements.py
@@ -68,7 +68,7 @@ class DownloadSpeedMeasurementWgetTestCase(TestCase):
             download_rate_unit=NetworkUnit("Mibit/s"),
             download_rate=133.6,
             download_size=11376,
-            download_size_unit=StorageUnit.megabit,
+            download_size_unit=StorageUnit.bit,
             errors=[],
         )
         self.invalid_wget = DownloadSpeedMeasurementResult(

--- a/measurement/plugins/download_speed/tests/test_measurements.py
+++ b/measurement/plugins/download_speed/tests/test_measurements.py
@@ -65,8 +65,8 @@ class DownloadSpeedMeasurementWgetTestCase(TestCase):
         self.valid_wget = DownloadSpeedMeasurementResult(
             id="test",
             url="http://validfakehost.com/test",
-            download_rate_unit=NetworkUnit("Mbit/s"),
-            download_rate=16.7,
+            download_rate_unit=NetworkUnit("Mibit/s"),
+            download_rate=133.6,
             download_size=11376,
             download_size_unit=StorageUnit.megabit,
             errors=[],

--- a/measurement/units.py
+++ b/measurement/units.py
@@ -13,6 +13,7 @@ class NetworkUnit(Enum):
 class StorageUnit(Enum):
     """Anticipated units for a storage style of measurement."""
 
+    bit     = "bit"
     kilobit = "kbit"
     megabit = "Mbit"
     kibibit = "Kibit"


### PR DESCRIPTION
Fixes several issues with the `download_speed` measurement:

* `download_rate` was being returned in bit/s instead of Mibit/s
* references were being made to `storage_unit` instead of `download_unit`
* `download_size_unit` was incorrect (`Storage.megabit` instead of the new `Storage.bit`)
* no support existed for `wget` output in `KB/s`