### PR TITLE
Add test run on review request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
     branches: [master]
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, review_requested]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Added
 * [420] (https://trello.com/c/TRSgdsJ4/420-update-netflix-test-to-capture-more-data-fields#comment-5ee09322d9002d808b4ad7a7) New netflixtest
+* Add test run on review request
 
 ## [1.0.5] (2020-05-06)
 ### Changed


### PR DESCRIPTION
To avoid running slow/expesnive tests every time a change is pushed
to a draft PR we only run the test suite when a draft is ready for
review. However we also want to run the test suite when a PR has
been updated based on feedback and a review is re-requested.