### PR TITLE
New IP Route Measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Added
+* [495](https://trello.com/c/dB5AYnxj/495-add-traceroute-to-honestybox-measurement) Add IP route measurement
+* Allow IPs as hosts for LatencyMeasurement
 
 ## [1.0.6] (2020-06-23)
 ### Added

--- a/measurement/plugins/ip_route/measurements.py
+++ b/measurement/plugins/ip_route/measurements.py
@@ -1,18 +1,49 @@
 """
 ip_route measurement, formerly the Traceroute measurement.
-"""
-import subprocess
+In a similar manner to the download_test, a list of hosts can be passed, in which case the one with the lowest latency is chosen.
+The results are returned in order as:
+ - IPRouteMeasurementResult
+ - LatencyResult of the host used to create the IPRouteMeasurement
+ - The LatencyResults from determining the initial latency
+Traceroute measurement is provided by the "scapy" library. Note that this library needs route privileges to create
+raw sockets, or to have the CAP_NET_RAW capability set.
 
-from scapy.all import traceroute
+"""
+import socket
+import validators
+from validators import ValidationFailure
+
+import scapy
 
 from measurement.measurements import BaseMeasurement
+from measurement.results import Error
 from measurement.plugins.ip_route.results import IPRouteMeasurementResult
 from measurement.plugins.latency.measurements import LatencyMeasurement
+
+ROUTE_ERRORS = {
+    "route-err": "iproute encountered an unknown error",
+    "route-address": "iproute failed to find socket address",
+    "route-permission": "iproute does not have permission to create a raw socket",
+}
 
 
 class IPRouteMeasurement(BaseMeasurement):
     def __init__(self, id, hosts, route_timeout=10, count=4):
         super(IPRouteMeasurement, self).__init__(id=id)
+
+        if len(hosts) < 1:
+            raise ValueError("At least one url must be provided.")
+        for host in hosts:
+            validated_url = validators.domain(host)
+            if isinstance(validated_url, ValidationFailure):
+                raise ValueError("`{host}` is not a valid host".format(host=host))
+
+        if count < 0:
+            raise ValueError(
+                "A value of {count} was provided for the number of pings. This must be a positive "
+                "integer or `0` to turn off the ping.".format(count=count)
+            )
+
         self.id = id
         self.hosts = hosts
         self.route_timeout = route_timeout
@@ -21,15 +52,14 @@ class IPRouteMeasurement(BaseMeasurement):
     def measure(self):
         initial_latency_results = self._find_least_latent_host(self.hosts)
         least_latent_host = initial_latency_results[0][0]
-
-        results = [self._get_traceroute_result(least_latent_host, self.route_timeout)]
+        results = [self._get_traceroute_result(least_latent_host)]
         if self.count > 0:
             latency_measurement = LatencyMeasurement(
                 self.id, least_latent_host, count=self.count
             )
             results.append(latency_measurement.measure()[0])
-
         results.extend([res for _, res in initial_latency_results])
+        print(results)
         return results
 
     def _find_least_latent_host(self, hosts):
@@ -39,30 +69,48 @@ class IPRouteMeasurement(BaseMeasurement):
         """
         initial_latency_results = []
         for host in hosts:
+            print("host: ", host)
             latency_measurement = LatencyMeasurement(self.id, host, count=2)
             initial_latency_results.append((host, latency_measurement.measure()[0]))
+        print("initial latency results: ", initial_latency_results)
         return sorted(
             initial_latency_results,
             key=lambda x: (x[1].average_latency is None, x[1].average_latency),
         )
 
-    def _get_traceroute_result(self, host, timeout):
+    def _get_traceroute_result(self, host):
         try:
-            traceroute_out = traceroute(host)
+            traceroute_out = scapy.layers.inet.traceroute(host)
             traceroute_trace = traceroute_out[0].get_trace()
             ip = list(traceroute_trace.keys())[0]
             hop_count = len(traceroute_trace[ip])
-        except subprocess.TimeoutExpired:
-            return None
+            trace_list = [
+                x[0] for x in traceroute_trace[ip].values()
+            ]  # Reshape dict into list of ips
+        except socket.gaierror as e:
+            return self._get_ip_route_error("route-address", traceback=str(e))
+        except PermissionError as e:
+            return self._get_ip_route_error("route-permission", traceback=str(e))
 
         return IPRouteMeasurementResult(
             id=self.id,
             host=host,
             ip=ip,
             hop_count=hop_count,
-            trace=traceroute_trace,
+            trace=trace_list,
             errors=[],
         )
 
     def _get_ip_route_error(self, key, traceback):
-        pass
+        return IPRouteMeasurementResult(
+            id=self.id,
+            host=None,
+            ip=None,
+            hop_count=None,
+            trace=None,
+            errors=[
+                Error(
+                    key=key, description=ROUTE_ERRORS.get(key, ""), traceback=traceback,
+                )
+            ],
+        )

--- a/measurement/plugins/ip_route/measurements.py
+++ b/measurement/plugins/ip_route/measurements.py
@@ -37,8 +37,11 @@ class IPRouteMeasurement(BaseMeasurement):
         if len(hosts) < 1:
             raise ValueError("At least one host must be provided.")
         for host in hosts:
-            validated_url = validators.domain(host)
-            if isinstance(validated_url, ValidationFailure):
+            validated_domain = validators.domain(host)
+            validated_ip = validators.ipv4(host)
+            if isinstance(validated_domain, ValidationFailure) & isinstance(
+                validated_ip, ValidationFailure
+            ):
                 raise ValueError("`{host}` is not a valid host".format(host=host))
 
         if count < 0:

--- a/measurement/plugins/ip_route/measurements.py
+++ b/measurement/plugins/ip_route/measurements.py
@@ -13,7 +13,10 @@ import socket
 import validators
 from validators import ValidationFailure
 
+# Both of these imports seem to be required in order to mock the traceroute function
 import scapy
+from scapy.layers.inet import traceroute
+
 
 from measurement.measurements import BaseMeasurement
 from measurement.results import Error
@@ -32,7 +35,7 @@ class IPRouteMeasurement(BaseMeasurement):
         super(IPRouteMeasurement, self).__init__(id=id)
 
         if len(hosts) < 1:
-            raise ValueError("At least one url must be provided.")
+            raise ValueError("At least one host must be provided.")
         for host in hosts:
             validated_url = validators.domain(host)
             if isinstance(validated_url, ValidationFailure):
@@ -59,7 +62,6 @@ class IPRouteMeasurement(BaseMeasurement):
             )
             results.append(latency_measurement.measure()[0])
         results.extend([res for _, res in initial_latency_results])
-        print(results)
         return results
 
     def _find_least_latent_host(self, hosts):
@@ -69,10 +71,8 @@ class IPRouteMeasurement(BaseMeasurement):
         """
         initial_latency_results = []
         for host in hosts:
-            print("host: ", host)
             latency_measurement = LatencyMeasurement(self.id, host, count=2)
             initial_latency_results.append((host, latency_measurement.measure()[0]))
-        print("initial latency results: ", initial_latency_results)
         return sorted(
             initial_latency_results,
             key=lambda x: (x[1].average_latency is None, x[1].average_latency),

--- a/measurement/plugins/ip_route/measurements.py
+++ b/measurement/plugins/ip_route/measurements.py
@@ -1,0 +1,68 @@
+"""
+ip_route measurement, formerly the Traceroute measurement.
+"""
+import subprocess
+
+from scapy.all import traceroute
+
+from measurement.measurements import BaseMeasurement
+from measurement.plugins.ip_route.results import IPRouteMeasurementResult
+from measurement.plugins.latency.measurements import LatencyMeasurement
+
+
+class IPRouteMeasurement(BaseMeasurement):
+    def __init__(self, id, hosts, route_timeout=10, count=4):
+        super(IPRouteMeasurement, self).__init__(id=id)
+        self.id = id
+        self.hosts = hosts
+        self.route_timeout = route_timeout
+        self.count = count
+
+    def measure(self):
+        initial_latency_results = self._find_least_latent_host(self.hosts)
+        least_latent_host = initial_latency_results[0][0]
+
+        results = [self._get_traceroute_result(least_latent_host, self.route_timeout)]
+        if self.count > 0:
+            latency_measurement = LatencyMeasurement(
+                self.id, least_latent_host, count=self.count
+            )
+            results.append(latency_measurement.measure()[0])
+
+        results.extend([res for _, res in initial_latency_results])
+        return results
+
+    def _find_least_latent_host(self, hosts):
+        """
+        Performs a latency test for each specified host
+        Returns a sorted list of LatencyResults, sorted by average latency
+        """
+        initial_latency_results = []
+        for host in hosts:
+            latency_measurement = LatencyMeasurement(self.id, host, count=2)
+            initial_latency_results.append((host, latency_measurement.measure()[0]))
+        return sorted(
+            initial_latency_results,
+            key=lambda x: (x[1].average_latency is None, x[1].average_latency),
+        )
+
+    def _get_traceroute_result(self, host, timeout):
+        try:
+            traceroute_out = traceroute(host)
+            traceroute_trace = traceroute_out[0].get_trace()
+            ip = list(traceroute_trace.keys())[0]
+            hop_count = len(traceroute_trace[ip])
+        except subprocess.TimeoutExpired:
+            return None
+
+        return IPRouteMeasurementResult(
+            id=self.id,
+            host=host,
+            ip=ip,
+            hop_count=hop_count,
+            trace=traceroute_trace,
+            errors=[],
+        )
+
+    def _get_ip_route_error(self, key, traceback):
+        pass

--- a/measurement/plugins/ip_route/measurements.py
+++ b/measurement/plugins/ip_route/measurements.py
@@ -83,7 +83,11 @@ class IPRouteMeasurement(BaseMeasurement):
 
     def _get_traceroute_result(self, host):
         try:
-            traceroute_out = scapy.layers.inet.traceroute(host)
+            # Test whether raw socket privileges exist:
+            socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+
+            # Commence traceroute test:
+            traceroute_out = scapy.layers.inet.traceroute(host, verbose=0)
             traceroute_trace = traceroute_out[0].get_trace()
             ip = list(traceroute_trace.keys())[0]
             hop_count = len(traceroute_trace[ip])

--- a/measurement/plugins/ip_route/results.py
+++ b/measurement/plugins/ip_route/results.py
@@ -1,0 +1,11 @@
+import collections
+import sys
+
+import six
+
+if six.PY3 and not sys.version_info.minor == 5:  # All python 3 expect for 3.5
+    from .results_py3 import *
+else:
+    IPRouteMeasurementResult = collections.namedtuple(
+        "IPRouteMeasurementResult", "id errors host hop_count ip trace",
+    )

--- a/measurement/plugins/ip_route/results_py3.py
+++ b/measurement/plugins/ip_route/results_py3.py
@@ -13,4 +13,4 @@ class IPRouteMeasurementResult(MeasurementResult):
     host: typing.Optional[str]
     hop_count: typing.Optional[int]
     ip: typing.Optional[str]
-    trace: typing.Optional[str]
+    trace: typing.Optional[list]

--- a/measurement/plugins/ip_route/results_py3.py
+++ b/measurement/plugins/ip_route/results_py3.py
@@ -1,0 +1,16 @@
+import typing
+from dataclasses import dataclass
+
+from measurement.results import MeasurementResult
+from measurement.units import TimeUnit, StorageUnit, RatioUnit, NetworkUnit
+
+
+@dataclass(frozen=True)
+class IPRouteMeasurementResult(MeasurementResult):
+    """Encapsulates the result from a IPRoute measurement.
+    """
+
+    host: typing.Optional[str]
+    hop_count: typing.Optional[int]
+    ip: typing.Optional[str]
+    trace: typing.Optional[str]

--- a/measurement/plugins/ip_route/tests/test_measurements.py
+++ b/measurement/plugins/ip_route/tests/test_measurements.py
@@ -1,8 +1,6 @@
 import socket
 from unittest import TestCase, mock
 
-from scapy.all import traceroute
-
 from measurement.plugins.ip_route.measurements import (
     IPRouteMeasurement,
     ROUTE_ERRORS,

--- a/measurement/plugins/ip_route/tests/test_measurements.py
+++ b/measurement/plugins/ip_route/tests/test_measurements.py
@@ -150,9 +150,10 @@ class IPRouteTestCase(TestCase):
             ),
         )
 
+    @mock.patch.object(socket, "socket")
     @mock.patch.object(LatencyMeasurement, "measure")
     @mock.patch("scapy.layers.inet.traceroute")
-    def test_measure(self, mock_get_traceroute, mock_latency_results):
+    def test_measure(self, mock_get_traceroute, mock_latency_results, mock_socket):
         iprm_three = IPRouteMeasurement(
             self.id, hosts=self.example_hosts_three, count=4
         )
@@ -176,8 +177,9 @@ class IPRouteTestCase(TestCase):
             ],
         )
 
+    @mock.patch.object(socket, "socket")
     @mock.patch("scapy.layers.inet.traceroute")
-    def test_get_trace_five(self, mock_get_traceroute):
+    def test_get_trace_five(self, mock_get_traceroute, mock_socket):
         mock_trace = mock.MagicMock()
         mock_trace.get_trace.return_value = self.example_trace_five
         mock_get_traceroute.return_value = [mock_trace, None]
@@ -186,8 +188,9 @@ class IPRouteTestCase(TestCase):
             self.example_result_five,
         )
 
+    @mock.patch.object(socket, "socket")
     @mock.patch("scapy.layers.inet.traceroute")
-    def test_get_trace_permission_err(self, mock_get_traceroute):
+    def test_get_trace_permission_err(self, mock_get_traceroute, mock_socket):
         mock_get_traceroute.side_effect = PermissionError(
             "[Errno 1] Operation not permitted"
         )
@@ -196,8 +199,9 @@ class IPRouteTestCase(TestCase):
             self.example_result_permission_err,
         )
 
+    @mock.patch.object(socket, "socket")
     @mock.patch("scapy.layers.inet.traceroute")
-    def test_get_trace_address_err(self, mock_get_traceroute):
+    def test_get_trace_address_err(self, mock_get_traceroute, mock_socket):
         mock_get_traceroute.side_effect = socket.gaierror(
             "[Errno -2] Name or service not known"
         )

--- a/measurement/plugins/ip_route/tests/test_measurements.py
+++ b/measurement/plugins/ip_route/tests/test_measurements.py
@@ -1,0 +1,336 @@
+import socket
+from unittest import TestCase, mock
+
+from scapy.all import traceroute
+
+from measurement.plugins.ip_route.measurements import (
+    IPRouteMeasurement,
+    ROUTE_ERRORS,
+)
+from measurement.plugins.latency.measurements import LatencyMeasurement
+from measurement.plugins.ip_route.results import IPRouteMeasurementResult
+from measurement.plugins.latency.results import LatencyMeasurementResult
+from measurement.results import Error
+from measurement.units import RatioUnit, TimeUnit, StorageUnit, NetworkUnit
+
+
+class IPRouteTestCase(TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.id = "1"
+        self.example_hosts_one = ["www.fakesitetwo.com"]
+        self.example_hosts_three = [
+            "www.fakesiteone.com",
+            "www.fakesitetwo.com",
+            "www.fakesitethree.com",
+        ]
+        self.iprm = IPRouteMeasurement(self.id, hosts=self.example_hosts_one, count=4)
+        self.example_trace_five = {
+            "final.ip": {
+                1: ("first.ip", False),
+                2: ("second.ip", False),
+                3: ("third.ip", False),
+                4: ("fourth.ip", False),
+                5: ("final.ip", True),
+            }
+        }
+        self.example_trace_five_list = [
+            "first.ip",
+            "second.ip",
+            "third.ip",
+            "fourth.ip",
+            "final.ip",
+        ]
+        self.example_result_five = IPRouteMeasurementResult(
+            id=self.id,
+            host=self.example_hosts_one[0],
+            hop_count=5,
+            ip="final.ip",
+            trace=self.example_trace_five_list,
+            errors=[],
+        )
+        self.example_result_permission_err = IPRouteMeasurementResult(
+            id=self.id,
+            host=None,
+            hop_count=None,
+            ip=None,
+            trace=None,
+            errors=[
+                Error(
+                    key="route-permission",
+                    description=ROUTE_ERRORS.get("route-permission", ""),
+                    traceback="[Errno 1] Operation not permitted",
+                )
+            ],
+        )
+        self.example_result_address_err = IPRouteMeasurementResult(
+            id=self.id,
+            host=None,
+            hop_count=None,
+            ip=None,
+            trace=None,
+            errors=[
+                Error(
+                    key="route-address",
+                    description=ROUTE_ERRORS.get("route-address", ""),
+                    traceback="[Errno -2] Name or service not known",
+                )
+            ],
+        )
+        self.example_latency_results_three = [
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesiteone.com",
+                    minimum_latency=None,
+                    average_latency=None,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesitetwo.com",
+                    minimum_latency=None,
+                    average_latency=25.0,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesitethree.com",
+                    minimum_latency=None,
+                    average_latency=999.0,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+        ]
+        self.example_least_latent_result = (
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesitetwo.com",
+                    minimum_latency=None,
+                    average_latency=24.9,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+        )
+
+    @mock.patch.object(LatencyMeasurement, "measure")
+    @mock.patch("scapy.layers.inet.traceroute")
+    def test_measure(self, mock_get_traceroute, mock_latency_results):
+        iprm_three = IPRouteMeasurement(
+            self.id, hosts=self.example_hosts_three, count=4
+        )
+        mock_trace = mock.MagicMock()
+        mock_trace.get_trace.return_value = self.example_trace_five
+        mock_get_traceroute.return_value = [mock_trace, None]
+        mock_latency_results.side_effect = [
+            self.example_latency_results_three[0],
+            self.example_latency_results_three[1],
+            self.example_latency_results_three[2],
+            self.example_least_latent_result,
+        ]
+        self.assertEqual(
+            iprm_three.measure(),
+            [
+                self.example_result_five,
+                self.example_least_latent_result[0],
+                self.example_latency_results_three[1][0],
+                self.example_latency_results_three[2][0],
+                self.example_latency_results_three[0][0],
+            ],
+        )
+
+    @mock.patch("scapy.layers.inet.traceroute")
+    def test_get_trace_five(self, mock_get_traceroute):
+        mock_trace = mock.MagicMock()
+        mock_trace.get_trace.return_value = self.example_trace_five
+        mock_get_traceroute.return_value = [mock_trace, None]
+        self.assertEqual(
+            self.iprm._get_traceroute_result(self.example_hosts_one[0]),
+            self.example_result_five,
+        )
+
+    @mock.patch("scapy.layers.inet.traceroute")
+    def test_get_trace_permission_err(self, mock_get_traceroute):
+        mock_get_traceroute.side_effect = PermissionError(
+            "[Errno 1] Operation not permitted"
+        )
+        self.assertEqual(
+            self.iprm._get_traceroute_result(self.example_hosts_one[0]),
+            self.example_result_permission_err,
+        )
+
+    @mock.patch("scapy.layers.inet.traceroute")
+    def test_get_trace_address_err(self, mock_get_traceroute):
+        mock_get_traceroute.side_effect = socket.gaierror(
+            "[Errno -2] Name or service not known"
+        )
+        self.assertEqual(
+            self.iprm._get_traceroute_result(self.example_hosts_one[0]),
+            self.example_result_address_err,
+        )
+
+
+class IPRouteMeasurementLeastLatentTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.id = "1"
+        self.example_hosts_three = [
+            "www.fakesiteone.com",
+            "www.fakesitetwo.com",
+            "www.fakesitethree.com",
+        ]
+        self.example_results_three = [
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesiteone.com",
+                    minimum_latency=None,
+                    average_latency=None,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesitetwo.com",
+                    minimum_latency=None,
+                    average_latency=25.0,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+            (
+                LatencyMeasurementResult(
+                    id=self.id,
+                    host="www.fakesitethree.com",
+                    minimum_latency=None,
+                    average_latency=999.0,
+                    maximum_latency=None,
+                    median_deviation=None,
+                    errors=[],
+                    packets_transmitted=None,
+                    packets_received=None,
+                    packets_lost=None,
+                    packets_lost_unit=None,
+                    time=None,
+                    time_unit=None,
+                ),
+            ),
+        ]
+        self.example_hosts_one = ["www.fakesiteone.com"]
+        self.example_results_one = [
+            LatencyMeasurementResult(
+                id=self.id,
+                host="www.fakesiteone.com",
+                minimum_latency=None,
+                average_latency=None,
+                maximum_latency=None,
+                median_deviation=None,
+                errors=[],
+                packets_transmitted=None,
+                packets_received=None,
+                packets_lost=None,
+                packets_lost_unit=None,
+                time=None,
+                time_unit=None,
+            ),
+        ]
+        self.iprm_three = IPRouteMeasurement(
+            self.id, hosts=self.example_hosts_three, count=4
+        )
+        self.iprm_one = IPRouteMeasurement(
+            self.id, hosts=self.example_hosts_three, count=4
+        )
+
+    @mock.patch.object(LatencyMeasurement, "measure")
+    def test_sort_least_latent_host(self, mock_latency_results):
+        mock_latency_results.side_effect = self.example_results_three
+        self.assertEqual(
+            self.iprm_three._find_least_latent_host(self.example_hosts_three),
+            [
+                (self.example_hosts_three[1], self.example_results_three[1][0]),
+                (self.example_hosts_three[2], self.example_results_three[2][0]),
+                (self.example_hosts_three[0], self.example_results_three[0][0]),
+            ],
+        )
+
+    @mock.patch.object(LatencyMeasurement, "measure")
+    def test_sort_one_host(self, mock_latency_results):
+        mock_latency_results.return_value = self.example_results_one
+        self.assertEqual(
+            self.iprm_one._find_least_latent_host(self.example_hosts_one),
+            [(self.example_hosts_one[0], self.example_results_one[0])],
+        )
+
+
+class IPRouteMeasurementCreationTestCase(TestCase):
+    def test_invalid_hosts(self, *args):
+        self.assertRaises(ValueError, IPRouteMeasurement, "test", ["invalid..host"])
+
+    def test_invalid_count(self, *args):
+        self.assertRaises(
+            TypeError,
+            IPRouteMeasurement,
+            "test",
+            ["validfakeurl.com"],
+            count="invalid-count",
+        )
+
+    def test_invalid_negative_count(self, *args):
+        self.assertRaises(
+            ValueError, IPRouteMeasurement, "test", ["validfakeurl.com"], count=-2,
+        )

--- a/measurement/plugins/ip_route/tests/test_measurements.py
+++ b/measurement/plugins/ip_route/tests/test_measurements.py
@@ -332,3 +332,6 @@ class IPRouteMeasurementCreationTestCase(TestCase):
         self.assertRaises(
             ValueError, IPRouteMeasurement, "test", ["validfakeurl.com"], count=-2,
         )
+
+    def test_valid_ip_host(self):
+        IPRouteMeasurement("test", ["1.1.1.1"])

--- a/measurement/plugins/latency/measurements.py
+++ b/measurement/plugins/latency/measurements.py
@@ -49,7 +49,10 @@ class LatencyMeasurement(BaseMeasurement):
             )
 
         validated_domain = validators.domain(host)
-        if isinstance(validated_domain, ValidationFailure):
+        validated_ip = validators.ipv4(host)
+        if isinstance(validated_domain, ValidationFailure) & isinstance(
+            validated_ip, ValidationFailure
+        ):
             raise ValueError("`{host}` is not a valid host".format(host=host))
 
         self.host = host

--- a/measurement/plugins/latency/tests/test_measurements.py
+++ b/measurement/plugins/latency/tests/test_measurements.py
@@ -232,3 +232,6 @@ class LatencyMeasurementInitTestCase(TestCase):
     def test_invalid_host_gets_raised(self):
         with self.assertRaises(ValueError):
             LatencyMeasurement("test", "%test")
+
+    def test_valid_ip_host(self):
+        LatencyMeasurement("test", "1.1.1.1")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,11 +1,10 @@
 [[package]]
 category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-marker = "python_version >= \"3.6\""
 name = "appdirs"
 optional = false
 python-versions = "*"
-version = "1.4.3"
+version = "1.4.4"
 
 [[package]]
 category = "dev"
@@ -13,7 +12,7 @@ description = "Atomic file writes."
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
+version = "1.4.0"
 
 [[package]]
 category = "dev"
@@ -21,12 +20,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
+version = "19.3.0"
 
 [package.extras]
-dev = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface", "sphinx", "pre-commit"]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
 docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest", "six", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
 category = "dev"
@@ -70,7 +70,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.4.5.2"
+version = "2020.6.20"
 
 [[package]]
 category = "main"
@@ -95,8 +95,8 @@ description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 name = "colorama"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.4.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
 
 [[package]]
 category = "dev"
@@ -117,11 +117,19 @@ version = "0.6"
 
 [[package]]
 category = "main"
-description = "Better living through Python with decorators"
+description = "Decorators for Humans"
 name = "decorator"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.4.0"
+version = "4.4.2"
+
+[[package]]
+category = "dev"
+description = "Distribution utilities"
+name = "distlib"
+optional = false
+python-versions = "*"
+version = "0.3.1"
 
 [[package]]
 category = "main"
@@ -133,14 +141,6 @@ version = "0.16"
 
 [[package]]
 category = "dev"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "dev"
 description = "A platform independent file lock."
 name = "filelock"
 optional = false
@@ -149,17 +149,20 @@ version = "3.0.12"
 
 [[package]]
 category = "dev"
-description = "the modular source code checker: pep8, pyflakes and co"
+description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.7.8"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.3"
 
 [package.dependencies]
-entrypoints = ">=0.3.0,<0.4.0"
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.5.0,<2.6.0"
-pyflakes = ">=2.1.0,<2.2.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
 category = "dev"
@@ -167,7 +170,7 @@ description = "Git Object Database"
 name = "gitdb"
 optional = false
 python-versions = ">=3.4"
-version = "4.0.4"
+version = "4.0.5"
 
 [package.dependencies]
 smmap = ">=3.0.1,<4"
@@ -178,7 +181,7 @@ description = "Python Git Library"
 name = "gitpython"
 optional = false
 python-versions = ">=3.4"
-version = "3.1.1"
+version = "3.1.7"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
@@ -189,7 +192,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
+version = "2.10"
 
 [[package]]
 category = "dev"
@@ -197,15 +200,32 @@ description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.21"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.7.0"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+
+[[package]]
+category = "dev"
+description = "Read resources from Python packages"
+marker = "python_version < \"3.7\""
+name = "importlib-resources"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "3.0.0"
+
+[package.dependencies]
+[package.dependencies.zipp]
+python = "<3.8"
+version = ">=0.4"
+
+[package.extras]
+docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
 category = "dev"
@@ -234,8 +254,8 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.4.0"
 
 [[package]]
 category = "dev"
@@ -243,10 +263,9 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1"
+version = "20.4"
 
 [package.dependencies]
-attrs = "*"
 pyparsing = ">=2.0.2"
 six = "*"
 
@@ -257,7 +276,7 @@ marker = "python_version < \"3.6\""
 name = "pathlib2"
 optional = false
 python-versions = "*"
-version = "2.3.4"
+version = "2.3.5"
 
 [package.dependencies]
 six = "*"
@@ -285,7 +304,7 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
@@ -301,7 +320,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.0"
+version = "1.9.0"
 
 [[package]]
 category = "dev"
@@ -309,7 +328,7 @@ description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 category = "dev"
@@ -317,7 +336,7 @@ description = "passive checker of Python programs"
 name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 category = "dev"
@@ -325,7 +344,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.2"
+version = "2.4.7"
 
 [[package]]
 category = "dev"
@@ -354,15 +373,15 @@ category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.7.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.9.0"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -379,7 +398,7 @@ marker = "python_version >= \"3.6\""
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.4.4"
+version = "2020.7.14"
 
 [[package]]
 category = "main"
@@ -387,7 +406,7 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.23.0"
+version = "2.24.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -400,12 +419,20 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
+category = "dev"
+description = "Scapy: interactive packet manipulation tool"
+name = "scapy"
+optional = false
+python-versions = "*"
+version = "2.4.2"
+
+[[package]]
 category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.12.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
 
 [[package]]
 category = "dev"
@@ -413,7 +440,7 @@ description = "A pure Python implementation of a sliding window memory map manag
 name = "smmap"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.2"
+version = "3.0.4"
 
 [[package]]
 category = "main"
@@ -452,32 +479,33 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
 python-versions = "*"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 category = "dev"
 description = "tox is a generic virtualenv management and test command line tool"
 name = "tox"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.14.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "3.17.1"
 
 [package.dependencies]
-filelock = ">=3.0.0,<4"
+colorama = ">=0.4.1"
+filelock = ">=3.0.0"
 packaging = ">=14"
-pluggy = ">=0.12.0,<1"
-py = ">=1.4.17,<2"
-six = ">=1.0.0,<2"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
 toml = ">=0.9.4"
-virtualenv = ">=14.0.0"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
 [package.dependencies.importlib-metadata]
 python = "<3.8"
-version = ">=0.12,<1"
+version = ">=0.12,<2"
 
 [package.extras]
-docs = ["sphinx (>=2.0.0,<3)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
-testing = ["freezegun (>=0.3.11,<1)", "pathlib2 (>=2.3.3,<3)", "pytest (>=4.0.0,<6)", "pytest-cov (>=2.5.1,<3)", "pytest-mock (>=1.10.0,<2)", "pytest-xdist (>=1.22.2,<2)", "pytest-randomly (>=1.2.3,<2)", "flaky (>=3.4.0,<4)", "psutil (>=5.6.1,<6)"]
+docs = ["sphinx (>=2.0.0)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
+testing = ["freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-xdist (>=1.22.2)", "pytest-randomly (>=1.0.0)", "flaky (>=3.4.0)", "psutil (>=5.6.1)"]
 
 [[package]]
 category = "dev"
@@ -520,12 +548,26 @@ category = "dev"
 description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "16.7.5"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "20.0.27"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<2"
+distlib = ">=0.3.1,<1"
+filelock = ">=3.0.0,<4"
+six = ">=1.9.0,<2"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12,<2"
+
+[package.dependencies.importlib-resources]
+python = "<3.7"
+version = ">=1.0"
 
 [package.extras]
-docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
-testing = ["pytest (>=4.0.0,<5)", "coverage (>=4.5.0,<5)", "pytest-timeout (>=1.3.0,<2)", "six (>=1.10.0,<2)", "pytest-xdist", "pytest-localserver", "pypiserver", "mock", "xonsh"]
+docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
+testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-freezegun (>=0.4.1)", "flaky (>=3)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
 category = "dev"
@@ -534,31 +576,29 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=2.7"
-version = "0.6.0"
-
-[package.dependencies]
-more-itertools = "*"
+version = "1.2.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "contextlib2", "unittest2"]
+testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "bb6dbbfe390fb955705bb97bf68e7e77c4250835ba9494f350c2944836e2607c"
+content-hash = "af5345c8c9cf95484be59f456e43e9faeac0330f17b46b8eaf9151a669237aba"
+lock-version = "1.0"
 python-versions = ">=3.5"
 
 [metadata.files]
 appdirs = [
-    {file = "appdirs-1.4.3-py2.py3-none-any.whl", hash = "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"},
-    {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 atomicwrites = [
-    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
-    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-19.1.0-py2.py3-none-any.whl", hash = "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79"},
-    {file = "attrs-19.1.0.tar.gz", hash = "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"},
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 bandit = [
     {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},
@@ -569,8 +609,8 @@ black = [
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 certifi = [
-    {file = "certifi-2020.4.5.2-py2.py3-none-any.whl", hash = "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"},
-    {file = "certifi-2020.4.5.2.tar.gz", hash = "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1"},
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -581,8 +621,8 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
-    {file = "colorama-0.4.1-py2.py3-none-any.whl", hash = "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"},
-    {file = "colorama-0.4.1.tar.gz", hash = "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"},
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 coverage = [
     {file = "coverage-4.4.2-cp26-cp26m-macosx_10_10_x86_64.whl", hash = "sha256:d1ee76f560c3c3e8faada866a07a32485445e16ed2206ac8378bd90dadffb9f0"},
@@ -631,40 +671,44 @@ dataclasses = [
     {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
 ]
 decorator = [
-    {file = "decorator-4.4.0-py2.py3-none-any.whl", hash = "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"},
-    {file = "decorator-4.4.0.tar.gz", hash = "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de"},
+    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
+    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
+distlib = [
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
-]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 flake8 = [
-    {file = "flake8-3.7.8-py2.py3-none-any.whl", hash = "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"},
-    {file = "flake8-3.7.8.tar.gz", hash = "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548"},
+    {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
+    {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
 ]
 gitdb = [
-    {file = "gitdb-4.0.4-py3-none-any.whl", hash = "sha256:ba1132c0912e8c917aa8aa990bee26315064c7b7f171ceaaac0afeb1dc656c6a"},
-    {file = "gitdb-4.0.4.tar.gz", hash = "sha256:6f0ecd46f99bb4874e5678d628c3a198e2b4ef38daea2756a2bfd8df7dd5c1a5"},
+    {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
+    {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.1-py3-none-any.whl", hash = "sha256:71b8dad7409efbdae4930f2b0b646aaeccce292484ffa0bc74f1195582578b3d"},
-    {file = "GitPython-3.1.1.tar.gz", hash = "sha256:6d4f10e2aaad1864bb0f17ec06a2c2831534140e5883c350d58b4e85189dab74"},
+    {file = "GitPython-3.1.7-py3-none-any.whl", hash = "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"},
+    {file = "GitPython-3.1.7.tar.gz", hash = "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-0.21-py2.py3-none-any.whl", hash = "sha256:9a9f75ce32e78170905888acbf2376a81d3f21ecb3bb4867050413411d3ca7a9"},
-    {file = "importlib_metadata-0.21.tar.gz", hash = "sha256:0c505102757e7fa28b9f0958d8bc81301159dea16e2649858c92edc158b78a83"},
+    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
+    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+]
+importlib-resources = [
+    {file = "importlib_resources-3.0.0-py2.py3-none-any.whl", hash = "sha256:d028f66b66c0d5732dae86ba4276999855e162a749c92620a38c1d779ed138a7"},
+    {file = "importlib_resources-3.0.0.tar.gz", hash = "sha256:19f745a6eca188b490b1428c8d1d4a0d2368759f32370ea8fb89cad2ab1106c3"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -675,16 +719,16 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
-    {file = "more_itertools-7.2.0-py3-none-any.whl", hash = "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"},
+    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
+    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
 ]
 packaging = [
-    {file = "packaging-19.1-py2.py3-none-any.whl", hash = "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9"},
-    {file = "packaging-19.1.tar.gz", hash = "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"},
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pathlib2 = [
-    {file = "pathlib2-2.3.4-py2.py3-none-any.whl", hash = "sha256:2156525d6576d21c4dcaddfa427fae887ef89a7a9de5cbfe0728b3aafa78427e"},
-    {file = "pathlib2-2.3.4.tar.gz", hash = "sha256:446014523bb9be5c28128c4d2a10ad6bb60769e78bd85658fe44a450674e0ef8"},
+    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
+    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
 ]
 pathspec = [
     {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
@@ -695,32 +739,32 @@ pbr = [
     {file = "pbr-5.4.5.tar.gz", hash = "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.0-py2.py3-none-any.whl", hash = "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6"},
-    {file = "pluggy-0.13.0.tar.gz", hash = "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"},
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
-    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
-    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
+    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
-    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.2-py2.py3-none-any.whl", hash = "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"},
-    {file = "pyparsing-2.4.2.tar.gz", hash = "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80"},
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
     {file = "pytest-3.10.1-py2.py3-none-any.whl", hash = "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec"},
     {file = "pytest-3.10.1.tar.gz", hash = "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.7.1.tar.gz", hash = "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"},
-    {file = "pytest_cov-2.7.1-py2.py3-none-any.whl", hash = "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6"},
+    {file = "pytest-cov-2.9.0.tar.gz", hash = "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322"},
+    {file = "pytest_cov-2.9.0-py2.py3-none-any.whl", hash = "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -736,39 +780,42 @@ pyyaml = [
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
-    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
-    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
-    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
-    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
-    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
-    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
-    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
-    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
-    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
+    {file = "regex-2020.7.14-cp27-cp27m-win32.whl", hash = "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"},
+    {file = "regex-2020.7.14-cp27-cp27m-win_amd64.whl", hash = "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88"},
+    {file = "regex-2020.7.14-cp36-cp36m-win32.whl", hash = "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4"},
+    {file = "regex-2020.7.14-cp36-cp36m-win_amd64.whl", hash = "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89"},
+    {file = "regex-2020.7.14-cp37-cp37m-win32.whl", hash = "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6"},
+    {file = "regex-2020.7.14-cp37-cp37m-win_amd64.whl", hash = "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
+    {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
+    {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
+    {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},
 ]
 requests = [
-    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
-    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+scapy = [
+    {file = "scapy-2.4.2.tar.gz", hash = "sha256:1baa048936207ceb1a4281a0e1e3b4317667c754872a0bb4734c5213c468e86a"},
 ]
 six = [
-    {file = "six-1.12.0-py2.py3-none-any.whl", hash = "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c"},
-    {file = "six-1.12.0.tar.gz", hash = "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"},
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 smmap = [
-    {file = "smmap-3.0.2-py2.py3-none-any.whl", hash = "sha256:52ea78b3e708d2c2b0cfe93b6fc3fbeec53db913345c26be6ed84c11ed8bebc1"},
-    {file = "smmap-3.0.2.tar.gz", hash = "sha256:b46d3fc69ba5f367df96d91f8271e8ad667a198d5a28e215a6c3d9acd133a911"},
+    {file = "smmap-3.0.4-py2.py3-none-any.whl", hash = "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4"},
+    {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
 ]
 speedtest-cli = [
     {file = "speedtest-cli-2.1.2.tar.gz", hash = "sha256:cf1d386222f94c324e3125ba9a0d187e46d4a13dca08c023bdb9a23096be2e54"},
@@ -782,13 +829,12 @@ stevedore = [
     {file = "stevedore-1.32.0.tar.gz", hash = "sha256:18afaf1d623af5950cc0f7e75e70f917784c73b652a34a12d90b309451b5500b"},
 ]
 toml = [
-    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
-    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
-    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tox = [
-    {file = "tox-3.14.0-py2.py3-none-any.whl", hash = "sha256:0bc216b6a2e6afe764476b4a07edf2c1dab99ed82bb146a1130b2e828f5bff5e"},
-    {file = "tox-3.14.0.tar.gz", hash = "sha256:c4f6b319c20ba4913dbfe71ebfd14ff95d1853c4231493608182f66e566ecfe1"},
+    {file = "tox-3.17.1-py2.py3-none-any.whl", hash = "sha256:cf130909a224515f6c894023150ccc860c4cf5ecad64f583b9d43ed1aa7e5da8"},
+    {file = "tox-3.17.1.tar.gz", hash = "sha256:5968c07b3aeea715ac2fe723a912e0b6a0c53bebad24fc37eb559b7497f217fa"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
@@ -821,10 +867,10 @@ validators = [
     {file = "validators-0.13.0.tar.gz", hash = "sha256:ea9bf8bf22aa692c205e12830d90b3b93950e5122d22bed9eb2f2fece0bba298"},
 ]
 virtualenv = [
-    {file = "virtualenv-16.7.5-py2.py3-none-any.whl", hash = "sha256:680af46846662bb38c5504b78bad9ed9e4f3ba2d54f54ba42494fdf94337fe30"},
-    {file = "virtualenv-16.7.5.tar.gz", hash = "sha256:f78d81b62d3147396ac33fc9d77579ddc42cc2a98dd9ea38886f616b33bc7fb2"},
+    {file = "virtualenv-20.0.27-py2.py3-none-any.whl", hash = "sha256:c51f1ba727d1614ce8fd62457748b469fbedfdab2c7e5dd480c9ae3fbe1233f1"},
+    {file = "virtualenv-20.0.27.tar.gz", hash = "sha256:26cdd725a57fef4c7c22060dba4647ebd8ca377e30d1c1cf547b30a0b79c43b4"},
 ]
 zipp = [
-    {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},
-    {file = "zipp-0.6.0.tar.gz", hash = "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"},
+    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
+    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ isort = "^4.3"
 pytest-cov = "^2.7"
 black = {version = "^19.10b0", allow-prereleases = true, python = ">=3.6"}
 bandit = "^1.6.2"
+scapy = "^2.4.2"
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
edit #2:
- Now attempts to create a socket in order to test privilege level
- changelog

edit: 
- Updated to fix the scapy import
- Both IPRouteMeasurement and LatencyMeasurement now accept IPv4 hosts.
- Associated tests

Implementation of the old functionality from the traceroute measurement in the new `honestybox-measurement` library.

This measurement uses the `scapy` library to generate the traceroute, and as a result will require either root privileges, or `CAP_NET_RAW` in order to run without errors.

The test is structured similarly to `DownloadSpeedMeasurement`, accepting a list of hosts as a parameter, then finding the least latent one to generate the test against. The results are returned as follows:
- IPRouteMeasurementResult, with
    - `host`
    - `ip`
    - `hop_count`
    - `trace` as a list of IPs.
- The LatencyMeasurementResult run after the trace, on the least latent host.
- The initial latency measurements, ordered by host.
