### PR TITLE
Fix IP route measurement permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Fixed
+* Fix IP route measurement permissions
 
 ## [1.0.8] (2020-08-18)
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -424,11 +424,12 @@ description = "Scapy: interactive packet manipulation tool"
 name = "scapy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "2.4.3"
+version = "2.4.4rc2"
 
 [package.extras]
 basic = ["ipython"]
 complete = ["ipython", "pyx", "cryptography (>=2.0)", "matplotlib"]
+docs = ["sphinx (>=2.2.0)", "sphinx_rtd_theme (>=0.4.3)", "tox (>=3.0.0)"]
 
 [[package]]
 category = "main"
@@ -595,7 +596,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "01cb53b3b81524ed4ff4e2615de955cc7a0ba2a7cd8b45223c6bae30e67156e2"
+content-hash = "84273035ce0d9f1341a259de2a1a148d2b50613cca85da503b283c35b6681efa"
 python-versions = ">=3.5, <4"
 
 [metadata.files]
@@ -818,7 +819,7 @@ requests = [
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 scapy = [
-    {file = "scapy-2.4.3.tar.gz", hash = "sha256:e2f8d11f6a941c14a789ae8b236b27bd634681f1b29b5e893861e284d234f6b0"},
+    {file = "scapy-2.4.4rc2.tar.gz", hash = "sha256:e24626211faf1b15de736c5cff6c3e25eb024cde796801b8f88bb6f007d95ab4"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ speedtest-cli = "^2.1"
 requests = "^2.23.0"
 statistics = "^1.0.3"
 youtube_dl = "^2020.6.16"
-scapy = "^2.4.3"
+scapy = {version = "^2.4.4-rc.2", allow-prereleases = true}
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"
 tox = "^3.13"


### PR DESCRIPTION
Bumps the `scapy` version to `2.4.4rc2` which includes a fix for [this issue](https://github.com/secdev/scapy/issues/2429) preventing `scapy` traceroutes from running even if the `CAP_NET_RAW` capability is present. This is required for the `ip_route` measurement.